### PR TITLE
Add a simple img_link tag

### DIFF
--- a/_plugins/ImgLink.rb
+++ b/_plugins/ImgLink.rb
@@ -1,0 +1,17 @@
+module Jekyll
+  class ImgLink < Liquid::Tag
+
+    def initialize(tag_name, filename, tokens)
+      super
+      @filename = filename.strip
+    end
+
+    def render(context)
+      html = "<a href=\"/assets/images/zoomzoom/#{@filename}\"><img src=\"/assets/images/zoomzoom/#{@filename}\"></a>"
+      template = Liquid::Template.parse(html)
+      template.render(context)
+    end
+  end
+end
+
+Liquid::Template.register_tag('img_link', Jekyll::ImgLink)

--- a/_posts/zoomzoom/2023-06-21-club-06.md
+++ b/_posts/zoomzoom/2023-06-21-club-06.md
@@ -15,27 +15,27 @@ Click on each image to see a larger version.
 
 <ul class="reference-photos">
   <li>
-    <a href="/assets/images/zoomzoom/z6-fargo.jpeg"><img src="/assets/images/zoomzoom/z6-fargo.jpeg"></a>
+    {% img_link z6-fargo.jpeg %}
     <span>Fargo</span>
   </li>
   <li>
-    <a href="/assets/images/zoomzoom/z6-northwest.jpeg"><img src="/assets/images/zoomzoom/z6-northwest.jpeg"></a>
+    {% img_link z6-northwest.jpeg %}
     <span>North by Northwest</span>
   </li>
   <li>
-    <a href="/assets/images/zoomzoom/z6-color-money.jpeg"><img src="/assets/images/zoomzoom/z6-color-money.jpeg"></a>
+    {% img_link z6-color-money.jpeg %}
     <span>The Color of Money</span>
   </li>
   <li>
-    <a href="/assets/images/zoomzoom/z6-bloodsimple.jpeg"><img src="/assets/images/zoomzoom/z6-bloodsimple.jpeg"></a>
+    {% img_link z6-bloodsimple.jpeg %}
     <span>Blood Simple</span>
   </li>
   <li>
-    <a href="/assets/images/zoomzoom/z6-alien.jpeg"><img src="/assets/images/zoomzoom/z6-alien.jpeg"></a>
+    {% img_link z6-alien.jpeg %}
     <span>Alien 2, I think?</span>
   </li>
   <li>
-    <a href="/assets/images/zoomzoom/z6-fargo2.jpeg"><img src="/assets/images/zoomzoom/z6-fargo2.jpeg"></a>
+    {% img_link z6-fargo2.jpeg %}
     <span>Fargo, again</span>
   </li>
 </ul>


### PR DESCRIPTION
It's pretty naive and hardcodes the asset path and probably isn't named great ... but it works

`{% img_link z6-northwest.jpeg %}`
replaces
`<a href="/assets/images/zoomzoom/z6-northwest.jpeg"><img src="/assets/images/zoomzoom/z6-northwest.jpeg"></a>`